### PR TITLE
Feat/auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ test {
 dependencies {
     compile "io.ktor:ktor-gson:$ktor_version"
     compile "org.postgresql:postgresql:42.2.2"
+    implementation "io.ktor:ktor-auth:$ktor_version"
+    implementation "io.ktor:ktor-auth-jwt:$ktor_version"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.0.1"
     implementation "org.jetbrains.exposed:exposed-core:$exposedVersion"
     implementation "org.jetbrains.exposed:exposed-dao:$exposedVersion"

--- a/resources/application.conf
+++ b/resources/application.conf
@@ -9,3 +9,7 @@ ktor {
         modules = [ com.dartcaller.ApplicationKt.module ]
     }
 }
+auth0 {
+    issuer = "https://dartcaller.eu.auth0.com/"
+    audience = "https://dartcaller.eu.auth0.com/api/v2/"
+}

--- a/src/ActiveGamesHandler.kt
+++ b/src/ActiveGamesHandler.kt
@@ -15,16 +15,15 @@ object ActiveGamesHandlerSingleton {
         this.games[game.gameEntity.id.toString()] = game
     }
 
-    suspend fun subscribe(socket: DefaultWebSocketSession, gameId: String) {
+    suspend fun subscribe(socket: Connection, gameId: String) {
         if (this.games[gameId] != null) {
             val subscriberList = this.subscribers.getValue(gameId)
-            val connection = Connection(socket)
-            subscriberList.add(connection)
+            subscriberList.add(socket)
             this.subscribers[gameId] = subscriberList
             this.games[gameId]?.let {
                 this.updateSubscribers(it)
             }
-            println("Subscribed socket ${connection.name}")
+            println("Subscribed socket ${socket.name}")
         }
     }
 

--- a/src/ActiveGamesHandler.kt
+++ b/src/ActiveGamesHandler.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.CancellationException
 
 object ActiveGamesHandlerSingleton {
     var games = mutableMapOf<String, Game>()
-    var subscribers = mutableMapOf<String, MutableList<Connection>>().withDefault { mutableListOf() }
+    private var subscribers = mutableMapOf<String, MutableList<Connection>>().withDefault { mutableListOf() }
 
     fun add(game: Game) {
         this.games[game.gameEntity.id.toString()] = game
@@ -59,6 +59,7 @@ object ActiveGamesHandlerSingleton {
     }
 
     suspend fun addScore(boardID: String, scoreString: String) {
+        ensureValidScore(scoreString)
         games.values.forEach {
             if (it.gameEntity.autoDartReco == boardID) {
                 it.addThrow(scoreString)
@@ -68,6 +69,7 @@ object ActiveGamesHandlerSingleton {
     }
 
     suspend fun correctScore(gameID: String, scoreToCorrect: CorrectScore) {
+        ensureValidScore(scoreToCorrect.scoreString)
         for (game in games.values.iterator()) {
             if (gameID == game.gameEntity.id.toString()) {
                 game.correctScore(scoreToCorrect.playerId, scoreToCorrect.scoreString)
@@ -81,6 +83,12 @@ object ActiveGamesHandlerSingleton {
         games[gameID]?.let {
             it.addLeg(leg)
             updateSubscribers(it)
+        }
+    }
+
+    private fun ensureValidScore(score: String) {
+        if (!"^(([SDT](?:\\d{1,3}))|-0){1,3}$".toRegex().matches(score)) {
+            throw IllegalArgumentException("Score arg does not follow valid form")
         }
     }
 }

--- a/src/Application.kt
+++ b/src/Application.kt
@@ -92,7 +92,7 @@ fun Application.module(testing: Boolean = false, dataSource: DataSource? = null)
                 .map { it.readText() }
                 .map { Pair(mapper.readValue<WsEvent>(it), it) }
                 .collect { (data, raw) ->
-                    when (connection.authenticated) {
+                    when (connection.authenticated || testing) {
                         true -> when (data.type) {
                             "CreateGame" -> createGame(mapper.readValue(raw), connection)
                             "JoinGame" -> joinGame(mapper.readValue(raw), connection)

--- a/src/Application.kt
+++ b/src/Application.kt
@@ -109,8 +109,12 @@ fun Application.module(testing: Boolean = false, dataSource: DataSource? = null)
         authenticate {
             post("/board/{boardID}/throw") {
                 call.parameters["boardID"]?.let {
-                    ActiveGamesHandlerSingleton.addScore(it, call.receiveText())
-                    call.respond(HttpStatusCode.OK)
+                    try {
+                        ActiveGamesHandlerSingleton.addScore(it, call.receiveText())
+                        call.respond(HttpStatusCode.OK)
+                    } catch (e: IllegalArgumentException) {
+                        call.respond(HttpStatusCode.BadRequest)
+                    }
                 }
             }
 
@@ -123,6 +127,8 @@ fun Application.module(testing: Boolean = false, dataSource: DataSource? = null)
                         call.respond(HttpStatusCode.OK)
                     } catch (e: IllegalStateException) {
                         call.respond(HttpStatusCode.Conflict)
+                    } catch (e: IllegalArgumentException) {
+                        call.respond(HttpStatusCode.BadRequest)
                     }
                 } else {
                     call.respond(HttpStatusCode.BadRequest)

--- a/src/Application.kt
+++ b/src/Application.kt
@@ -106,6 +106,7 @@ fun Application.module(testing: Boolean = false, dataSource: DataSource? = null)
             }
         }
 
+        authenticate {
             post("/board/{boardID}/throw") {
                 call.parameters["boardID"]?.let {
                     ActiveGamesHandlerSingleton.addScore(it, call.receiveText())

--- a/src/routes/ws/Connection.kt
+++ b/src/routes/ws/Connection.kt
@@ -8,4 +8,5 @@ class Connection(val session: DefaultWebSocketSession) {
         var lastId = AtomicInteger(0)
     }
     val name = "user${lastId.getAndIncrement()}"
+    var authenticated = false
 }

--- a/src/routes/ws/authenticateWs.kt
+++ b/src/routes/ws/authenticateWs.kt
@@ -1,0 +1,59 @@
+package com.dartcaller.routes.ws
+
+import com.auth0.jwk.UrlJwkProvider
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.interfaces.DecodedJWT
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.typesafe.config.ConfigFactory
+import io.ktor.http.cio.websocket.*
+import java.security.interfaces.RSAPublicKey
+
+fun verifyToken(token: String): DecodedJWT {
+    val jwkProvider = UrlJwkProvider(ConfigFactory.load().getString("auth0.issuer"))
+
+    val jwt = JWT.decode(token)
+    val jwk = jwkProvider.get(jwt.keyId)
+
+    val publicKey = jwk.publicKey as? RSAPublicKey ?: throw Exception("Invalid key type") // safe
+
+    val algorithm = when (jwk.algorithm) {
+        "RS256" -> Algorithm.RSA256(publicKey, null)
+        else -> throw Exception("Unsupported algorithm")
+    }
+
+    val verifier = JWT.require(algorithm) // signature
+        .withIssuer(ConfigFactory.load().getString("auth0.issuer")) // iss
+        .withAudience(ConfigFactory.load().getString("auth0.audience")) // aud
+        .build()
+
+    return verifier.verify(token)
+}
+
+class AuthenticateEvent(
+    val accessToken: String,
+) : WsEvent("Authenticate")
+
+class AuthenticatedResult(
+    val authenticated: Boolean
+) {
+    fun toJson(): String {
+        return jacksonObjectMapper().writeValueAsString(this)
+    }
+}
+
+suspend fun authenticateWs(event: AuthenticateEvent, socket: Connection) {
+    println("Not yet authenticated: ${socket.name}")
+    try {
+        verifyToken(event.accessToken)
+        socket.authenticated = true
+        println("Authenticated: ${socket.name}")
+        socket.session.outgoing.send(
+            Frame.Text(
+                AuthenticatedResult(true).toJson()
+            )
+        )
+    } catch (e: Exception) {
+        println(e)
+    }
+}

--- a/src/routes/ws/createGame.kt
+++ b/src/routes/ws/createGame.kt
@@ -11,7 +11,7 @@ class GameCreateEvent(
     val players: List<String>, val gameMode: String
 ) : WsEvent("GameEvent")
 
-suspend fun createGame(event: GameCreateEvent, socket: DefaultWebSocketSession) {
+suspend fun createGame(event: GameCreateEvent, socket: Connection) {
     val game = transaction {
         val startScore = if (event.gameMode == "301") 301 else 501
 

--- a/src/routes/ws/createGame.kt
+++ b/src/routes/ws/createGame.kt
@@ -11,11 +11,15 @@ class GameCreateEvent(
     val players: List<String>, val gameMode: String
 ) : WsEvent("GameEvent")
 
+fun sanitizePlayerName(string: String): String {
+    return "[^a-zA-Z]".toRegex().replace(string, "")
+}
+
 suspend fun createGame(event: GameCreateEvent, socket: Connection) {
     val game = transaction {
         val startScore = if (event.gameMode == "301") 301 else 501
 
-        val playerEntities = event.players.map { PlayerController.create(it) }
+        val playerEntities = event.players.map { PlayerController.create(sanitizePlayerName(it)) }
         val newGameEntity = GameController.create("proto", event.gameMode)
         val newLegEntity = LegController.create(newGameEntity.id, 0, false, 0, 0, startScore)
         playerEntities.forEachIndexed { index, playerEntity ->

--- a/src/routes/ws/joinGame.kt
+++ b/src/routes/ws/joinGame.kt
@@ -1,12 +1,11 @@
 package com.dartcaller.routes.ws
 
 import com.dartcaller.ActiveGamesHandlerSingleton
-import io.ktor.http.cio.websocket.*
 
 class GameJoinEvent(
     val gameID: String,
 ) : WsEvent("GameEvent")
 
-suspend fun joinGame(event: GameJoinEvent, socket: DefaultWebSocketSession) {
+suspend fun joinGame(event: GameJoinEvent, socket: Connection) {
     ActiveGamesHandlerSingleton.subscribe(socket, event.gameID)
 }


### PR DESCRIPTION
# Description
Added:
- added player sanitisation
- validation of rest api input
- Client Credentials Flow for communication with python backend
- Authorisation Code Flow with Bearer Token verification for WS and REST

## Ticker
https://linear.app/dart-caller/issue/DAR-57/improve-security-when-pairing-dartboard-with-web