### PR TITLE
BIT-2: try 3 ways to navigate linear command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Tests](https://github.com/DartCaller/api/actions/workflows/main.yml/badge.svg)](https://github.com/DartCaller/api/actions/workflows/main.yml)
 ![](https://img.shields.io/github/license/DartCaller/api)
 ![](https://img.shields.io/tokei/lines/github/DartCaller/api)
-
+ 
 # Ktor Backend
 This repository contains the Kotlin backend, which acts as a middle man between the dart recognition python server (https://github.com/DartCaller/darts-recognition) and the user-facing frontend (https://github.com/DartCaller/web).
 


### PR DESCRIPTION
## Related Pull Requests
<!---
<relatedPrs>
-->
- https://github.com/DartCaller/MainReadMe/pull/1
<!---
</relatedPrs>
-->

# What
Trigger the github bot with `!update` and it'll check if the branch is a valid linear-ticket-referencing branch and if so, it'll replace the `Completes BIT-2

https://linear.app/issue/BIT-2` placeholder with the proper linear ticket info.

`!update` also checks if there is another open PR in this github organisation that references the same linear issue as this pr does, and if it finds multiple PRs referencing the same linear ticket, it'll populate these under the `https://github.com/DartCaller/api/pull/11` above.

# Linear Tickets
<!---
<linearTickets>
-->
Completes BIT-2

https://linear.app/issue/BIT-2
<!---
</linearTickets>
-->